### PR TITLE
Minor fix for Top link

### DIFF
--- a/themes/FC/assets/css/single.css
+++ b/themes/FC/assets/css/single.css
@@ -734,6 +734,7 @@ pre {
     transition: visibility 0.3s ease, opacity 0.3s ease;
     font-size: var(--xl);
     color: var(--secondary);
+    padding: .5rem !important;
 }
 
 .top-link:hover {


### PR DESCRIPTION
One more small change. But is a class really necessary for this? It would be better to give the property via id. As you can see, the correction made is simply centering the arrow. It is in the center on all screen sizes.
Before:
![resim](https://github.com/user-attachments/assets/6fd31d7e-a2d0-41dc-9654-eea78f84e578)
After:
![resim](https://github.com/user-attachments/assets/7aaf9e71-dbc3-4a5d-8b07-05c4b65202cc)
