### PR TITLE
Fixes v0.147.1

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -18,7 +18,7 @@ pagination:
 
 permalinks:
   page:
-    news: /news/:slugorfilename/
+    news: /news/:slugorcontentbasename/
 
 minify:
   disableXML: true

--- a/themes/FC/layouts/shortcodes/collapse.html
+++ b/themes/FC/layouts/shortcodes/collapse.html
@@ -1,5 +1,5 @@
 <p>
-  <details {{- if (eq (.Get "openByDefault") true) -}} open=true {{- end -}}>
+  <details{{ if (eq (.Get "openByDefault") true) }} open{{ end }}>
     <summary markdown="span">
       {{ .Get 0 | $.Page.RenderString }}
     </summary>


### PR DESCRIPTION
Tried running hugo (v0.147.1) but got two issues:
```
WARN  deprecated: the ":slugorfilename" permalink token was deprecated in Hugo 0.144.0 and will be removed in a future release. Use ":slugorcontentbasename" instead.
hugo: collected modules in 1849 msError: html/template:_shortcodes/collapse.html:2:18: {{if}} branches end in different contexts: {stateAttr delimSpaceOrTagEnd urlPartNone jsCtxRegexp attrNone elementNone <nil>}, {stateTag delimNone urlPartNone jsCtxRegexp attrNone elementNone <nil>}
```

I still don't quite understand the template stuff in hugo so please check `themes/FC/layouts/shortcodes/collapse.html` before merging.