### PR TITLE
Footer: Add a sitemap to the footer

### DIFF
--- a/content/community/index.en.md
+++ b/content/community/index.en.md
@@ -9,9 +9,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 4
+    weight: 6
   footer:
-    weight: 4
+    weight: 6
 ---
 
 [![LINK TO GITHUB](1.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/community/index.fr.md
+++ b/content/community/index.fr.md
@@ -9,9 +9,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 4
+    weight: 6
   footer:
-    weight: 4
+    weight: 6
 ---
 
 [![LINK TO GITHUB](1.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/contribute/index.en.md
+++ b/content/contribute/index.en.md
@@ -9,9 +9,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 6
+    weight: 8
   footer:
-    weight: 6
+    weight: 8
 ---
 
 [![LINK TO GITHUB](2.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/contribute/index.fr.md
+++ b/content/contribute/index.fr.md
@@ -9,9 +9,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 6
+    weight: 8
   footer:
-    weight: 6
+    weight: 8
 ---
 
 [![LINK TO GITHUB](2.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/documentation/index.en.md
+++ b/content/documentation/index.en.md
@@ -9,9 +9,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 5
+    weight: 7
   footer:
-    weight: 5
+    weight: 7
 ---
 
 [![LINK TO GITHUB](0.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/documentation/index.fr.md
+++ b/content/documentation/index.fr.md
@@ -9,9 +9,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 5
+    weight: 7
   footer:
-    weight: 5
+    weight: 7
 ---
 
 [![LINK TO GITHUB](0.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/donate/_index.en.md
+++ b/content/donate/_index.en.md
@@ -9,11 +9,11 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 7
+    weight: 9
     params:
       style: button
   footer:
-    weight: 7
+    weight: 9
 ---
 
 [comment]: # (Please do not add content in this Donate _index file. The layout of the Donate page is generated from template rules by the theme.)

--- a/content/donate/_index.fr.md
+++ b/content/donate/_index.fr.md
@@ -9,11 +9,11 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 7
+    weight: 9
     params:
       style: button
   footer:
-    weight: 7
+    weight: 9
 ---
 
 [comment]: # (Please do not add content in this Donate _index file. The layout of the Donate page is generated from template rules by the theme.)

--- a/content/download/index.fr.md
+++ b/content/download/index.fr.md
@@ -10,9 +10,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 2
+    weight: 3
   footer:
-    weight: 2
+    weight: 3
 params:
   thanksText: "Merci de télécharger FreeCAD !"
   donateText: "♥︎ Parrainer son dévelopement"

--- a/content/features/index.en.md
+++ b/content/features/index.en.md
@@ -10,9 +10,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 1
+    weight: 2
   footer:
-    weight: 1
+    weight: 2
 ---
 
 [![LINK TO GITHUB](5.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/features/index.fr.md
+++ b/content/features/index.fr.md
@@ -10,9 +10,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 1
+    weight: 2
   footer:
-    weight: 1
+    weight: 2
 ---
 
 [![LINK TO GITHUB](5.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/homepage/index.en.md
+++ b/content/homepage/index.en.md
@@ -1,9 +1,12 @@
 ---
-title: "FreeCAD Homepage highlights"
+title: "Homepage"
 description: "FreeCAD highlights on the Homepage"
 date: 2024-05-22T08:04:23+12:00
 author: "FreeCAD"
 type: homepage
+menus:
+  footer:
+    weight: 1
 ---
 
 [![LINK TO GITHUB](assembly2.webp "Link to GitHub")](https://github.com/freecad)

--- a/content/homepage/index.fr.md
+++ b/content/homepage/index.fr.md
@@ -1,49 +1,40 @@
 ---
-title: "Download"
-description: "Let the FreeCAD adventure unfold!"
+title: "Accueil"
+description: "FreeCAD points forts sur la page d'accueil"
 date: 2024-05-22T08:04:23+12:00
 author: "FreeCAD"
-type: download
-cover:
-  image: 4.webp
-  caption: "a cover caption"
-  alt: "a cover alternative title"
+type: homepage
 menus:
-  main:
-    weight: 3
   footer:
-    weight: 3
-params:
-  thanksText: "Thank you for downloading FreeCAD!"
-  donateText: "♥︎ Sponsor its development"
+    weight: 1
 ---
 
-[![LINK TO GITHUB](4.webp "Link to GitHub")](https://github.com/freecad)
+[![LINK TO GITHUB](assembly2.webp "Link to GitHub")](https://github.com/freecad)
 
-## First Download Block
+## First Highlight Block
 
 This is a text in the first block to go in the right. This is a text in the first block. This is a text in the first block to go in the right. This is a text in the first block to go in the right. This is a text in the first block to go in the right.
 
 +++
 
-## Second Download Block
+## Second Highlight Block
 
 This is a text in the second block to go in the left. This is a text in the second block. This is a text in the second block to go in the left. This is a text in the second block to go in the left. This is a text in the second block to go in the left. This is a text in the second block.
 
-![](4.webp)
+![](bulb.webp)
 
 +++
 
-![](4.webp)
+![](assembly1.webp)
 
-## Third Download Block
+## Third Highlight Block
 
 This is a text in the third block to go in the right. This is a text in the third block. This is a text in the third block to go in the right. This is a text in the third block to go in the right. This is a text in the third block to go in the right. This is a text in the third block.
 
 +++
 
-## Fourth Download Block
+## Fourth Highlight Block
 
 This is a text in the fourth block to go in the left. This is a text in the fourth block. This is a text in the fourth block to go in the left. This is a text in the fourth block to go in the left. This is a text in the fourth block to go in the left. This is a text in the fourth block.
 
-![](4.webp)
+![](fem.webp)

--- a/content/news/_index.en.md
+++ b/content/news/_index.en.md
@@ -10,9 +10,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 3
+    weight: 5
   footer:
-    weight: 3
+    weight: 5
 ---
 
 [comment]: # (Please do not add content in this News _index file. The layout of the News page is generated from template rules by the theme.)

--- a/content/news/_index.fr.md
+++ b/content/news/_index.fr.md
@@ -10,9 +10,9 @@ cover:
   alt: "a cover alternative title"
 menus:
   main:
-    weight: 3
+    weight: 5
   footer:
-    weight: 3
+    weight: 5
 ---
 
 [comment]: # (Please do not add content in this News _index file. The layout of the News page is generated from template rules by the theme.)

--- a/content/releases/_index.en.md
+++ b/content/releases/_index.en.md
@@ -7,6 +7,9 @@ cover:
   image: 7.webp
   caption: "a cover caption"
   alt: "a cover alternative title"
+menus:
+  footer:
+    weight: 4
 ---
 
 [comment]: # (Please do not add content in this Releases _index file. The layout of the Releases page is generated from template rules by the theme.)

--- a/content/releases/_index.fr.md
+++ b/content/releases/_index.fr.md
@@ -7,6 +7,9 @@ cover:
   image: 7.webp
   caption: "a cover caption"
   alt: "a cover alternative title"
+menus:
+  footer:
+    weight: 4
 ---
 
 [comment]: # (Please do not add content in this Releases _index file. The layout of the Releases page is generated from template rules by the theme.)

--- a/themes/FC/assets/css/footer.css
+++ b/themes/FC/assets/css/footer.css
@@ -1,7 +1,7 @@
 /* This CSS stylesheet defines the style of the site footer */
 
 
-.site-footer {
+.footer-row {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -17,14 +17,53 @@
     background: var(--theme);
 }
 
-.site-footer span:last-child {
+.footer-row span:last-child {
     white-space: nowrap;
 }
 
-.site-footer a {
+.footer-row a {
     color: var(--link-color);
 }
 
-.site-footer a:hover {
+.footer-row a:hover {
     color: var(--link-hover-color);
+}
+
+.footer-sitemap {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.footer-column {
+    flex: 1 1 200px;
+    margin: 0;
+    padding-right: 1rem;
+    text-align: left;
+}
+
+.footer-column h4 {
+    color: var(--tertiary);
+    margin-bottom: 0.5rem;
+}
+
+.footer-column ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.footer-column li {
+    margin-bottom: 0.3rem;
+}
+
+.footer-column a {
+    color: var(--tertiary);
+    text-decoration: none;
+}
+
+.footer-column a:hover {
+    text-decoration: underline;
 }

--- a/themes/FC/assets/css/footer.css
+++ b/themes/FC/assets/css/footer.css
@@ -33,14 +33,13 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    max-width: 1200px;
     margin: 0 auto;
 }
 
 .footer-column {
-    flex: 1 1 200px;
+    flex: 1;
     margin: 0;
-    padding-right: 1rem;
+    padding-right: 2rem;
     text-align: left;
 }
 
@@ -65,5 +64,5 @@
 }
 
 .footer-column a:hover {
-    text-decoration: underline;
+    text-decoration: none;
 }

--- a/themes/FC/assets/css/header.css
+++ b/themes/FC/assets/css/header.css
@@ -112,12 +112,12 @@ body:not(.dark) #sun {
     color: var(--link-hover-color);
 }
 
-.menu-list #menu-active:not(.button) {
+.menu-active:not(.button) {
     color: var(--primary);
     box-shadow: 0 var(--line) 0 var(--primary);
 }
 
-.menu-list #menu-active:hover {
+.menu-active:hover {
     color: var(--link-hover-color);
     box-shadow: var(--link-hover-underline-shadow)
 }
@@ -144,13 +144,13 @@ body:not(.dark) #sun {
     transition: none;
 }
 
-.menu-list :is(.button:hover, .button#menu-active:hover) {
+.menu-list :is(.button:hover, .button.menu-active:hover) {
     color: var(--cover);
     background: var(--link-hover-color);
     box-shadow: none;
 }
 
-.menu-list .button#menu-active  {
+.button.menu-active  {
     color: var(--cover);
     background: black;
 }

--- a/themes/FC/assets/css/media.css
+++ b/themes/FC/assets/css/media.css
@@ -169,7 +169,7 @@
         display: inline-block;
     }
 
-    .menu-list #menu-active:not(.button) {
+    .menu-list .menu-active:not(.button) {
         margin: 0.5rem;
         padding: 0;
         color: var(--primary);
@@ -177,7 +177,7 @@
         box-shadow: 0 var(--line)0 var(--primary);
     }
 
-    .menu-list #menu-active:hover {
+    .menu-list .menu-active:hover {
         color: var(--link-hover-color);
         box-shadow: var(--link-hover-underline-shadow);
     }

--- a/themes/FC/layouts/partials/footer.html
+++ b/themes/FC/layouts/partials/footer.html
@@ -1,25 +1,44 @@
 <footer class="site-footer">
-  {{- if site.Copyright -}}
+  <div class="footer-row">
+    <div class="footer-sitemap">
+      {{ range .Site.Sections }}
+        {{ $excluded := slice "donate" "admin" }}
+        {{ if not (in $excluded .Section) }}
+          <div class="footer-column">
+            <h4><a href="{{ .RelPermalink }}">{{ .Title }}</a></h4>
+            <ul>
+              {{ range first 5 .Pages }}
+                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+              {{ end }}
+            </ul>
+          </div>
+        {{ end }}
+      {{ end }}
+    </div>
+  </div>
+  <div class="footer-row">
+    {{- if site.Copyright -}}
+      <span>
+        {{ site.Copyright | .RenderString }}
+      </span>
+    {{- else -}}
+      <span>
+        &copy; {{ now.Year }} <a href="{{ "" | relLangURL }}">
+          {{ site.Title | .RenderString }}
+        </a>
+      </span>
+    {{- end -}}
     <span>
-      {{ site.Copyright | .RenderString }}
-    </span>
-  {{- else -}}
-    <span>
-      &copy; {{ now.Year }} <a href="{{ "" | relLangURL }}">
-        {{ site.Title | .RenderString }}
+      <a href="https://creativecommons.org/licenses/by-sa/4.0/">
+        CC BY-SA
       </a>
     </span>
-  {{- end -}}
-  <span>
-    <a href="https://creativecommons.org/licenses/by-sa/4.0/">
-      CC BY-SA
-    </a>
-  </span>
-  <span>
-    Made with ♥︎ thanks to <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">
-      Hugo
-    </a>
-  </span>
+    <span>
+      Made with ♥︎ thanks to <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">
+        Hugo
+      </a>
+    </span>
+  </div>
 </footer>
 
 <script>

--- a/themes/FC/layouts/partials/footer.html
+++ b/themes/FC/layouts/partials/footer.html
@@ -1,21 +1,51 @@
+{{- $currentPage := . -}}
+{{- $menuFooter := site.Menus.footer -}}
+{{- if not $menuFooter -}}
+  {{- $menuFooter = site.Sites.Default.Menus.footer -}}
+{{- end -}}
+
 <footer class="site-footer">
   <div class="footer-row">
     <div class="footer-sitemap">
-      {{ range .Site.Sections }}
-        {{ $excluded := slice "donate" "admin" }}
-        {{ if not (in $excluded .Section) }}
+      {{- range $menuFooter -}}
+      {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL)) -}}
+      {{- $page_url := $currentPage.RelPermalink -}}
           <div class="footer-column">
-            <h4><a href="{{ .RelPermalink }}">{{ .Title }}</a></h4>
-            <ul>
-              {{ range first 5 .Pages }}
-                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-              {{ end }}
-            </ul>
+            <h4>
+              <a href="{{ if in .URL "homepage" }}{{ "" | relLangURL }}{{- else -}}{{ .URL }}{{- end -}}" title="{{ .Title | default .Name | plainify }}"
+              {{- with .Params.style -}} class="{{ . }}" {{- end -}}
+              {{- if or (strings.HasPrefix $page_url $menu_item_url) (and ($currentPage.IsHome) (in .URL "homepage")) -}}
+                class="menu-active" aria-current="page"
+              {{- end -}}
+              {{- if .Params.External -}}
+                target="_blank"
+              {{- end -}} >
+                {{ .Title | $.Page.RenderString }}
+                {{- if .Params.External -}}
+                  <span class="external-link">
+                    {{ safeHTML (index $.Site.Data.svg "external-link") }}
+                  </span>
+                {{- end -}}
+              </a>
+            </h4>
+            {{- with .Page.CurrentSection -}}
+              {{- if not .IsHome -}}
+                <ul>
+                  {{ range first 5 .RegularPages }}
+                    <li>
+                      <a href="{{ .RelPermalink }}" title="{{ .Title | default .Name | plainify }}">
+                        {{ .Title | $.Page.RenderString }}
+                      </a>
+                    </li>
+                  {{ end }}
+                </ul>
+              {{- end -}}
+            {{- end -}}
           </div>
-        {{ end }}
-      {{ end }}
+      {{- end -}}
     </div>
   </div>
+
   <div class="footer-row">
     {{- if site.Copyright -}}
       <span>

--- a/themes/FC/layouts/partials/header.html
+++ b/themes/FC/layouts/partials/header.html
@@ -62,7 +62,7 @@
             <a href="{{ $menu_item_url }}" title="{{ .Title | default .Name | plainify }}"
             {{- with .Params.style -}} class="{{ . }}" {{- end -}}
             {{- if strings.HasPrefix $page_url $menu_item_url -}}
-              id="menu-active" aria-current="page"
+              class="menu-active" aria-current="page"
             {{- end -}}
             {{- if .Params.External -}}
               target="_blank"


### PR DESCRIPTION
Creates a sitemap in the footer based on the site's Sections and Pages (similar to blender's site).

Css still needs work to handle more sections as it tends to grow in height quite a lot.

<img width="744" alt="image" src="https://github.com/user-attachments/assets/cc3c2eb0-19b6-4027-8beb-8d4eb54709f0" />
